### PR TITLE
Add support for feedburner feed link

### DIFF
--- a/_includes/themes/mark-reid/default.html
+++ b/_includes/themes/mark-reid/default.html
@@ -13,6 +13,9 @@
 	<meta name="keywords" content="{{ page.keywords }}">
 	{% endif %}
 	
+	{% if site.author.feedburner %}
+  	<link rel="alternate" type="application/atom+xml" href="http://feeds.feedburner.com/{{ site.author.feedburner }}" title="RSS feed" />
+	{% endif %}
 	{% if page.feed %}
   	<link rel="alternate" type="application/atom+xml" href="{{ page.feed }}" title="RSS feed" />
 	{% endif %}


### PR DESCRIPTION
JB's _config.yml has the author.feedburner property, but the mark-reid theme doesn't use it. This pull request is to add it to the default layout.

I'm new to JB, so if I did this wrong, please be gentle. I'm happy to make whatever changes you recommend.
