### PR TITLE
Prefix links with BASE_PATH

### DIFF
--- a/_includes/themes/mark-reid/default.html
+++ b/_includes/themes/mark-reid/default.html
@@ -37,10 +37,10 @@
     </h1>
     <ul class="nav">
       <li><a class="home" href="{{ HOME_PATH }}">Home</a></li>
-      <li><a  href="/archive.html">Archive</a></li>
-      <li><a  href="/pages.html">Pages</a></li>
-      <li><a  href="/categories.html">Categories</a></li>
-      <li><a  href="/tags.html">Tags</a></li>
+      <li><a  href="{{ BASE_PATH }}/archive.html">Archive</a></li>
+      <li><a  href="{{ BASE_PATH }}/pages.html">Pages</a></li>
+      <li><a  href="{{ BASE_PATH }}/categories.html">Categories</a></li>
+      <li><a  href="{{ BASE_PATH }}/tags.html">Tags</a></li>
     </ul>
   </div>
 
@@ -49,7 +49,7 @@
   <div id="footer">
   	<address>
   		<span class="copyright">
-  			Content by <a href="/info/site.html">{{ site.author.name }}</a>. Design by 
+  			Content by <a href="{{ BASE_PATH }}/info/site.html">{{ site.author.name }}</a>. Design by 
   			<a href="http://mark.reid.name/">Mark Reid</a>
   			<br/>
   			(<a rel="licence" href="http://creativecommons.org/licenses/by-nc-sa/3.0/">Some rights reserved</a>)			


### PR DESCRIPTION
Links in the default.html page are not prefixed, meaning they will fail if the site is served from a basepath other than "/". This change prefixes them all with {{ BASE_PATH }}, which is recommended in the jeckyl-bootstrap config file.
